### PR TITLE
Add limits to Park acres to avoid errors

### DIFF
--- a/frontend/src/main/components/Parks/ParkForm.js
+++ b/frontend/src/main/components/Parks/ParkForm.js
@@ -83,6 +83,8 @@ function ParkForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     data-testid={testIdPrefix + "-acres"}
                     id="acres"
                     type="number"
+                    min={0}
+                    max={999999999}
                     isInvalid={Boolean(errors.state)}
                     {...register("acres", {
                         required: "Number of acres is required.",


### PR DESCRIPTION
In this PR, we add limits to the acres input for Parks so that it doesn't give errors if the number is too large. Also doesn't allow park to be less than 0 acres now. Zero acres would indicate a non-existent park, I guess...